### PR TITLE
Pretty json formatter and health check filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ jobs:
     env: DEPS="nameko>=2.12.0"
   - python: 3.5
     env: DEPS="nameko>=2.12.0"
-
-matrix:
   allow_failures:
     - python: 3.6
       env: DEPS="--pre nameko"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Version 1.3.0
 Release 2020-12-02
 
 * Add PrettyJSONFormatter useful for development of Nameko services
+* Add HealthCheckTraceFilter useful for filtering out healthcheck entrypoint traces
 
 
 Version 1.2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@ Release Notes
 =============
 
 
+Version 1.3.0
+-------------
+
+Release 2020-12-02
+
+* Add PrettyJSONFormatter useful for development of Nameko services
+
+
 Version 1.2.0
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,6 @@
 Nameko Entrypoint Tracer
 ========================
 
-TODO introduction ...
-
 Usage
 =====
 

--- a/nameko_tracer/filters.py
+++ b/nameko_tracer/filters.py
@@ -97,3 +97,15 @@ class TruncateResponseFilter(BaseTruncateFilter):
 
 
 TruncateRequestFilter = TruncateCallArgsFilter
+
+
+class HealthCheckTraceFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            return record.worker_ctx.entrypoint.url not in [
+                "/health-check",
+                "/health_check",
+                "/healthcheck",
+            ]
+        except AttributeError:
+            return True

--- a/nameko_tracer/formatters.py
+++ b/nameko_tracer/formatters.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from functools import partial
 
 from nameko_tracer import constants
 
@@ -8,16 +9,20 @@ def default(obj):
     return str(obj)
 
 
-def serialise(obj):
-    return json.dumps(obj, default=default)
+serialise = partial(json.dumps, default=default)
 
 
 class JSONFormatter(logging.Formatter):
     """ Format trace data as JSON string
     """
+    def __init__(self, **option):
+        self.option = option
 
     def format(self, record):
-        return serialise(getattr(record, constants.TRACE_KEY))
+        return serialise(getattr(record, constants.TRACE_KEY), **self.option)
+
+
+PrettyJSONFormatter = partial(JSONFormatter, indent=4, sort_keys=True)
 
 
 class ElasticsearchDocumentFormatter(JSONFormatter):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='nameko-tracer',
-    version='1.2.0',
+    version='1.3.0',
     description='Nameko extension logging entrypoint processing metrics',
     author='student.com',
     author_email='wearehiring@student.com',

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -67,7 +67,9 @@ def test_truncate_call_args(
     stage,
 ):
 
-    filter_ = filters.TruncateCallArgsFilter(entrypoints=entrypoints, max_len=max_len)
+    filter_ = filters.TruncateCallArgsFilter(
+        entrypoints=entrypoints, max_len=max_len
+    )
 
     logger.addFilter(filter_)
 
@@ -183,7 +185,9 @@ def test_truncate_response(
     truncated,
 ):
 
-    filter_ = filters.TruncateResponseFilter(entrypoints=entrypoints, max_len=max_len)
+    filter_ = filters.TruncateResponseFilter(
+        entrypoints=entrypoints, max_len=max_len
+    )
 
     logger.addFilter(filter_)
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -8,53 +8,75 @@ from nameko_tracer import constants, formatters
 
 
 @pytest.mark.parametrize(
-    ('input_', 'expected_output'),
+    ("input_", "expected_output"),
     (
         (
-            {'datetime': datetime(2017, 7, 7, 12, 0)},
-            '{"datetime": "2017-07-07 12:00:00"}'
+            {"datetime": datetime(2017, 7, 7, 12, 0)},
+            '{"datetime": "2017-07-07 12:00:00"}',
         ),
         ({None}, '"{None}"'),
-    )
+    ),
 )
-def test_json_serialiser_will_deal_with_datetime(input_, expected_output):
-
+def test_json_serialiser(input_, expected_output):
     log_record = Mock()
     setattr(log_record, constants.TRACE_KEY, input_)
 
-    assert (
-        formatters.JSONFormatter().format(log_record) == expected_output)
+    assert formatters.JSONFormatter().format(log_record) == expected_output
 
 
 @pytest.mark.parametrize(
-    ('key', 'value_in', 'expected_value_out'),
+    "formatter",
+    (
+        formatters.JSONFormatter(indent=4, sort_keys=True),
+        formatters.PrettyJSONFormatter(),
+    ),
+)
+def test_pretty_json_serialiser(formatter):
+    log_record = Mock()
+    setattr(log_record, constants.TRACE_KEY, {"show": {"this": "pretty"}})
+
+    expected_output = "\n".join(
+        (
+            "{",
+            '    "show": {',
+            '        "this": "pretty"',
+            "    }",
+            "}",
+        )
+    )
+
+    assert formatter.format(log_record) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("key", "value_in", "expected_value_out"),
     (
         (
             constants.CONTEXT_DATA_KEY,
-            {'should': ('be', 'serialised')},
+            {"should": ("be", "serialised")},
             '{"should": ["be", "serialised"]}',
         ),
         (
             constants.REQUEST_KEY,
-            ('should', 'be', 'serialised'),
+            ("should", "be", "serialised"),
             '["should", "be", "serialised"]',
         ),
         (
             constants.RESPONSE_KEY,
-            {'should': ('be', 'serialised')},
+            {"should": ("be", "serialised")},
             '{"should": ["be", "serialised"]}',
         ),
         (
             constants.EXCEPTION_ARGS_KEY,
-            {'should': ('be', 'serialised')},
+            {"should": ("be", "serialised")},
             '{"should": ["be", "serialised"]}',
         ),
         (
-            'some-other-key',
-            {'should': ['NOT', 'be', 'serialised']},
-            {'should': ['NOT', 'be', 'serialised']},
+            "some-other-key",
+            {"should": ["NOT", "be", "serialised"]},
+            {"should": ["NOT", "be", "serialised"]},
         ),
-    )
+    ),
 )
 def test_elasticsearch_document_serialiser(key, value_in, expected_value_out):
 


### PR DESCRIPTION
This PR adds two things:
* HealthCheckTraceFilter
* PrettyJSONFormatter

### HealthCheckTraceFilter
A new filter which helps to remove trace noise when using healtchecks. An example of a helthcheck entrypoint serving kubernetes `livenessProbe`:

```python
# service.py

class Service:
    name = "my-service"

    @http("GET", "/health-check")
    def health_check(self, request):
        # can test dependencies here too ...
        return 200, "OK"
```

Configuration:
```yaml
# config.yaml

LOGGING:
  version: 1
  filters:
    skip_health_check_trace:
      (): nameko_tracer.filters.HealthCheckTraceFilter
  handlers:
    tracer:
      class: logging.StreamHandler
  loggers:
    nameko_tracer:
      level: INFO
      handlers: [tracer]
      filters:
        - skip_health_check_trace
```

```yaml
# deployment.yaml

kind: Deployment  
spec:
  template:
    spec:
      containers:
      - name: my-service
        image: image-with-my-service
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /health-check
            port: 8000
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 20
```

### PrettyJSONFormatter
A new formatter which helps with TDD integration of Nameko services.

Configuration:
```yaml
# config.yaml

LOGGING:
  version: 1
  formatters:
    tracer:
      (): nameko_tracer.formatters.PrettyJSONFormatter
  handlers:
    tracer:
      formatter: tracer
      class: logging.StreamHandler
  loggers:
    nameko_tracer:
      level: INFO
      handlers: [tracer]
```

Output:
```
2020-12-02 10:25:10,529 [INFO] [inventory_service] [nameko_tracer] [inventory-service.get_inventory_group_links.c3280cb5-814b-4578-9d
48-b29581e496ae] entrypoint call trace
{
    "call_args": "{'inventory_group_id': 'fe679243-625f-44c3-991f-42c3685a298d', 'request': {'url': 'http://localhost:8010/inventory-
groups/fe679243-625f-44c3-991f-42c3685a298d/inventory-types?property_id=82', 'method'",
    "call_args_length": 505,
    "call_args_redacted": false,
   "call_args_truncated": true,
    "call_id": "inventory-service.get_inventory_group_links.c3280cb5-814b-4578-9d48-b29581e496ae",
    "call_id_stack": [
        "inventory-service.get_inventory_group_links.c3280cb5-814b-4578-9d48-b29581e496ae"
    ],
    "context_data": {
        "call_id_stack": [
            "inventory-service.get_inventory_group_links.c3280cb5-814b-4578-9d48-b29581e496ae"
        ]
    },
    "entrypoint_name": "get_inventory_group_links",
    "entrypoint_type": "HttpRequestHandler",
    "hostname": "yo",
    "origin_call_id": null,
    "response": "{'content_type': 'application/json', 'data': '[{\"deviation_type\": \"absolute\", \"inventory_type_id\": 655, \"inventory_group_id\": \"fe679243-625f-44c3-991f-42c3685a298d\", \"order\": 1, \"deviation_amount\": \"0",
    "response_length": 412,
    "response_status": "success",
    "response_time": 0.007879,
    "response_truncated": true,
    "service": "inventory-service",
    "stage": "response",
    "timestamp": "2020-12-02 09:25:10.537359"
}
```
